### PR TITLE
Add option to destroy clients on error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## Version 0.6.0 (2015-mm-dd)
+ - New `destroyOnError` option to remove clients from pool after a query fails
  - Discourages node 0.8.x
 
 ## Version 0.5.1 (2015-02-20)

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -80,9 +80,13 @@ var extTypeName = {};
  * - size
  * - idleTimeout
  * - reapInterval
+ * @param {Object} options
+ * - {Boolean} destroyOnError whether the client must be removed from the pool on query error or not
  * @returns PSQL
  */
-var PSQL = function(connectionParams, poolParams) {
+var PSQL = function(connectionParams, poolParams, options) {
+    options = options || {};
+    options.destroyOnError = options.destroyOnError || false;
 
     var me = {
         POOL_DEFAULT_SIZE: 16,
@@ -269,12 +273,17 @@ var PSQL = function(connectionParams, poolParams) {
                 };
                 client.on('notice', noticeListener);
 
+                var errorHappened = false;
+                query.on('error', function() {
+                    errorHappened = true;
+                });
+
                 // NOTE: for some obscure reason passing "done" directly
                 //       as the listener works but can be slower
                 //      (by x2 factor!)
                 query.on('end', function() {
                     client.removeListener('notice', noticeListener);
-                    done();
+                    done(options.destroyOnError && errorHappened);
                 });
                 next(null, query, client);
             },
@@ -315,15 +324,16 @@ var PSQL = function(connectionParams, poolParams) {
                 }
                 client.query(sql, this);
             },
-            function(err, res){
+            function(err, res) {
 
                 // Release client to the pool
+                //
+                // NOTE: If we pass a true value to finish() the client will be removed from the pool.
+                // We use that behaviour to remove clients when they err
+                //
                 // should this be postponed to after the callback ?
-                // NOTE: if we pass a true value to finish() the client
-                //       will be removed from the pool.
-                //       We don't want this. Not now.
                 if ( finish ) {
-                    finish();
+                    finish(options.destroyOnError && !!err);
                 }
 
                 callback(err, res);

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+require('../setup');
+
+var _ = require('underscore');
+var assert = require('assert');
+var PSQL = require('../../lib/psql');
+
+var dbopts_auth = {
+    host: global.settings.db_host,
+    port: global.settings.db_port,
+    user: _.template(global.settings.db_user, {user_id: 1}),
+    dbname: _.template(global.settings.db_base_name, {user_id: 1}),
+    pass: _.template(global.settings.db_user_pass, {user_id: 1})
+};
+
+var POOL_PARAMS = {};
+
+describe('transaction', function() {
+
+    it('query can be run after transaction fails', function(done){
+        var pg = new PSQL(dbopts_auth, POOL_PARAMS, { destroyOnError: true });
+        var sql = "BEGIN; select error; COMMIT;";
+        pg.query(sql, function(err) {
+            assert.ok(err);
+            assert.equal(err.message, 'column "error" does not exist');
+
+            pg.query('select 1 as foo', function(err, result) {
+                assert.ok(result);
+                assert.equal(result.rows[0].foo, 1);
+                done();
+            });
+        });
+    });
+
+    it('evented query can be run after transaction fails', function(done){
+        var pg = new PSQL(dbopts_auth, POOL_PARAMS, { destroyOnError: true });
+        var sql = "BEGIN; select error; COMMIT;";
+        pg.eventedQuery(sql, function(err, query) {
+
+            query.on('error', function(err) {
+                assert.ok(err);
+                assert.equal(err.message, 'column "error" does not exist');
+            });
+
+            query.on('end', function() {
+                pg.eventedQuery('select 1 as foo', function(err, query) {
+                    query.on('row', function(row) {
+                        assert.ok(row);
+                        assert.equal(row.foo, 1);
+                        done();
+                    });
+                });
+            });
+
+        });
+    });
+
+});


### PR DESCRIPTION
New `destroyOnError` option to remove clients from pool after a query fails
