### PR TITLE
Fix comment stripping with multiple comment lines

### DIFF
--- a/lib/query_wrapper.js
+++ b/lib/query_wrapper.js
@@ -60,7 +60,7 @@ QueryWrapper.prototype.query = function () {
         return this.sqlQuery;
     }
     // Strip comments
-    this.sqlQuery = this.sqlQuery.replace(/--.*(\n|$)/g, '');
+    this.sqlQuery = this.sqlQuery.replace(/--.*(\n|$)/g, ' ');
 
     var cte = '';
 

--- a/lib/query_wrapper.js
+++ b/lib/query_wrapper.js
@@ -60,7 +60,7 @@ QueryWrapper.prototype.query = function () {
         return this.sqlQuery;
     }
     // Strip comments
-    this.sqlQuery = this.sqlQuery.replace(/(^|\n)\s*--.*\n/g, '');
+    this.sqlQuery = this.sqlQuery.replace(/--.*(\n|$)/g, '');
 
     var cte = '';
 

--- a/test/unit/query_wrapper.test.js
+++ b/test/unit/query_wrapper.test.js
@@ -116,4 +116,16 @@ describe('query_wrapper', function() {
 
         assert.equal(outputSql, expectedSql);
     });
+    
+    it('Query with comment', function(){
+        var out = new QueryWrapper("--Selects 1\nSELECT 1").window(1,0).query();
+
+        assert.equal(out, "SELECT * FROM ( SELECT 1) AS cdbq_1 LIMIT 1 OFFSET 0");
+    });
+    
+    it('Query with multiple comments', function(){
+        var out = new QueryWrapper("SELECT--C\n--2\n1").window(1,0).query();
+
+        assert.equal(out, "SELECT * FROM (SELECT  1) AS cdbq_1 LIMIT 1 OFFSET 0");
+    });
 });


### PR DESCRIPTION
Fixes CartoDB/CartoDB-SQL-API#274
When two comments are in consecutive lines, the previous regex skips the second one (as it matches two \n).

CR @rochoa 
