### PR TITLE
Remove destroyOnError option as we need to always destroy on error

### DIFF
--- a/lib/psql.js
+++ b/lib/psql.js
@@ -216,13 +216,11 @@ var extTypeName = {};
  * - idleTimeout
  * - reapInterval
  * @param {Object} options
- * - {Boolean} destroyOnError whether the client must be removed from the pool on query error or not
  * - {Number} maxRowSize The max number of bytes for a row, when exceeded the query will throw an error.
  * @returns PSQL
  */
 var PSQL = function(connectionParams, poolParams, options) {
     options = options || {};
-    options.destroyOnError = options.destroyOnError || false;
     options.maxRowSize = options.maxRowSize || undefined;
 
     var me = {
@@ -419,10 +417,12 @@ var PSQL = function(connectionParams, poolParams, options) {
                 };
                 client.on('notice', noticeListener);
 
-                query.on('error', function() {
+                var gotError = false;
+                query.on('error', function(err) {
                     client.removeListener('maxRowSize', maxRowSizeListener);
                     client.removeListener('notice', noticeListener);
-                    done(options.destroyOnError);
+                    gotError = true;
+                    done(err);
                 });
 
                 client.once('maxRowSize', maxRowSizeListener);
@@ -433,7 +433,9 @@ var PSQL = function(connectionParams, poolParams, options) {
                 query.on('end', function() {
                     client.removeListener('maxRowSize', maxRowSizeListener);
                     client.removeListener('notice', noticeListener);
-                    done();
+                    if (!gotError) {
+                        done();
+                    }
                 });
 
                 next(null, query, client);
@@ -488,7 +490,7 @@ var PSQL = function(connectionParams, poolParams, options) {
                 //
                 // should this be postponed to after the callback ?
                 if ( finish ) {
-                    finish(options.destroyOnError && !!err);
+                    finish(!!err);
                 }
 
                 callback(err, res);


### PR DESCRIPTION
This avoids returning clients in a bad state to the pool.
