### PR TITLE
Remove check for SET statements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-## Version 0.9.1 (2017-mm-dd)
+## Version 0.10.0 (2017-mm-dd)
+ - Remove check for SET statements.
 
 ## Version 0.9.0 (2017-08-09)
  - Expose `pg.end` #26.

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -9,12 +9,6 @@ var stdTypeName = require('./oid-to-name');
 // Holds a typeId->typeName mapping for each database ever connected to
 var extTypeName = {};
 
-function isForbiddenQuery(sql) {
-    return sql.match(/^\s*set\s+/i);
-}
-var FORBIDDEN_SET_QUERY_ERROR = new SyntaxError("SET command is forbidden");
-FORBIDDEN_SET_QUERY_ERROR.http_status = 403;
-
 pg.on('error', function () {
     // All errors will be handled synchronously or at client level
     // this avoid uncaughtException
@@ -233,13 +227,6 @@ var PSQL = function(connectionParams, poolParams, options) {
         }
         params = params || [];
 
-        if (isForbiddenQuery(sql)) {
-            // Err if illegal operations are detected.
-            // NOTE: this check is weak hack, better database permissions should be used instead.
-            // NOTE: illegal table access is checked in main app
-            return callback(FORBIDDEN_SET_QUERY_ERROR);
-        }
-
         this.connect(function(err, client, done) {
             if (err) {
                 return callback(err);
@@ -300,13 +287,6 @@ var PSQL = function(connectionParams, poolParams, options) {
           readonly = callback;
           callback = params;
           params = [];
-        }
-
-        if (isForbiddenQuery(sql)) {
-            // Err if illegal operations are detected.
-            // NOTE: this check is weak hack, better database permissions should be used instead.
-            // NOTE: illegal table access is checked in main app
-            return callback(FORBIDDEN_SET_QUERY_ERROR);
         }
 
         this.connect(function(err, client, done) {

--- a/test/integration/psql.test.js
+++ b/test/integration/psql.test.js
@@ -90,36 +90,6 @@ describe('psql config-object:' + useConfigObject, function() {
         });
     });
 
-    it('should fail for /^set/ queries', function(done){
-        var psql = new PSQL(dbopts_auth);
-        var sql = "set statement_timeout=1000; select 1";
-        psql.query(sql, function(err){
-            assert.ok(err);
-            assert.equal(err.message, 'SET command is forbidden');
-            done();
-        });
-    });
-
-    it('should fail for /^\\s+set/ queries', function(done){
-        var psql = new PSQL(dbopts_auth);
-        var sql = " set statement_timeout=1000; select 1";
-        psql.query(sql, function(err){
-            assert.ok(err);
-            assert.equal(err.message, 'SET command is forbidden');
-            done();
-        });
-    });
-
-    it('should fail for /^set/ eventend queries', function(done){
-        var psql = new PSQL(dbopts_auth);
-        var sql = "set statement_timeout=1000; select 1";
-        psql.eventedQuery(sql, function(err){
-            assert.ok(err);
-            assert.equal(err.message, 'SET command is forbidden');
-            done();
-        });
-    });
-
     it('eventedQuery provisions a cancel mechanism to abort queries', function (done) {
         var psql = new PSQL(dbopts_auth);
         psql.eventedQuery("SELECT 1 as foo", function(err, query, queryCanceller) {


### PR DESCRIPTION
The previous check had a small typo in the regular expression. The latest version of the regular expression was fixed, but that introduces a lot of unexpected corner cases.

The code itself was pointing:

```js
// Err if illegal operations are detected.
// NOTE: this check is weak hack, better database permissions should be used instead.
// NOTE: illegal table access is checked in main app
```

There are alternatives to do a set that won't be caught by this regex, so it doesn't make sense to keep it here.