### PR TITLE
0.6.1 fix pg vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/CartoDB/node-cartodb-psql/blob/master/LICENSE"
     }],
     "dependencies": {
-        "pg": "git://github.com/CartoDB/node-postgres.git#2.6.2-cdb3",
+        "pg": "git://github.com/CartoDB/node-postgres.git#2.6.2-cdb4",
         "debug": "~2.2.0",
         "step": "~0.0.5",
         "underscore": "~1.6.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cartodb-psql",
     "description": "A simple postgres wrapper with logic about username and database to connect",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "main": "./lib/psql.js",
     "repository": {
         "type": "git",


### PR DESCRIPTION
New version for the old 0.6.1 version to fix the pg vulnerability

-----------------

More info about pg vulnerability 
https://node-postgres.com/announcements#2017-08-12-code-execution-vulnerability