### PR TITLE
Update node-pq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,27 +4,21 @@ dist: trusty
 env:
   - PGUSER=postgres PGDATABASE=postgres
 
-node_js: "6"
-addons:
-  postgresql: "9.6"
+env:
+    - POSTGRESQL_VERSION="9.5"
+    - POSTGRESQL_VERSION="10"
 
-matrix:
-  include:
-    - node_js: "0.10"
-      addons:
-        postgresql: "9.3"
-    - node_js: "0.10"
-      addons:
-        postgresql: "9.5"
-    - node_js: "4"
-      addons:
-        postgresql: "9.5"
-    - node_js: "6"
-      addons:
-        postgresql: "9.3"
-    - node_js: "6"
-      addons:
-        postgresql: "9.4"
-    - node_js: "6"
-      addons:
-        postgresql: "9.5"
+node_js:
+  - "6"
+  - "8"
+
+
+before_install:
+  - sudo service postgresql stop;
+  - sudo apt-get install -y --allow-unauthenticated --no-install-recommends --no-install-suggests postgresql-$POSTGRESQL_VERSION postgresql-client-$POSTGRESQL_VERSION postgresql-server-dev-$POSTGRESQL_VERSION
+  - echo -e "# TYPE  DATABASE        USER            ADDRESS                 METHOD \nlocal   all             postgres                                trust\nlocal   all             all                                     trust\nhost    all             all             127.0.0.1/32            trust"  | sudo tee /etc/postgresql/$POSTGRESQL_VERSION/main/pg_hba.conf
+  - export PGPORT=`grep ^port /etc/postgresql/$POSTGRESQL_VERSION/main/postgresql.conf | awk '{print $3}'`
+  - export PGUSER=postgres
+  - export PGDATABASE=postgres
+  - sudo service postgresql restart $POSTGRESQL_VERSION;
+  - sed -i 's/5432/'"$PGPORT"'/g' config/environments/test.js

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Version 0.11.0 (2018-05-28)
+ - Use node-postgres to `6.4.2-cdb1`.
+
 ## Version 0.10.2 (2017-10-03)
  - Upgrade debug to 3.x.
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     ],
     "license": "BSD-3-Clause",
     "dependencies": {
-        "pg": "cartodb/node-postgres#6.1.6-cdb1",
         "debug": "^3.1.0",
+        "pg": "CartoDB/node-postgres#449fac1d6da711ffcc6694ae3c89f85244f48bdc",
         "underscore": "~1.6.0"
     },
     "devDependencies": {
@@ -29,5 +29,7 @@
     "scripts": {
         "test": "make test-all"
     },
-    "engines": { "node": ">= 0.8 < 0.11" }
+    "engines": {
+        "node": ">= 4.5.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "debug": "^3.1.0",
-        "pg": "CartoDB/node-postgres#449fac1d6da711ffcc6694ae3c89f85244f48bdc",
+        "pg": "CartoDB/node-postgres#6.4.2-cdb1",
         "underscore": "~1.6.0"
     },
     "devDependencies": {

--- a/test/integration/psql.test.js
+++ b/test/integration/psql.test.js
@@ -84,7 +84,7 @@ describe('psql config-object:' + useConfigObject, function() {
 
             psql = new PSQL(dbopts_anon);
             psql.query("INSERT INTO distributors3 (id, name) VALUES (1, 'fishy')", function(err/*, result*/){
-                assert.equal(err.message, 'permission denied for relation distributors3');
+                assert.ok(err.message.match(/permission denied for .+? distributors3/));
                 done();
             });
         });


### PR DESCRIPTION
- Updates to use https://github.com/CartoDB/node-postgres/pull/5
- Fixes tests strings to be compatible with PG10/11
- Matrix with node 6, 8 and PG 9.5, 10

This is to check the tests first before making a new release in node-postgres. If everything is OK I'll create a new node-postgres release and change the commit id and use the tag instead.

Closes https://github.com/CartoDB/node-cartodb-psql/issues/30