### PR TITLE
 Include host and port in the dbkey

### DIFF
--- a/lib/psql.js
+++ b/lib/psql.js
@@ -160,7 +160,7 @@ var PSQL = function(connectionParams, poolParams, options) {
     };
 
     me.dbkey = function(){
-        return this.database(); // + ":" + this.dbhost() + ":" + me.dbport();
+        return this.database() + ":" + this.dbhost() + ":" + me.dbport();
     };
 
     me.ensureTypeCache = function(cb) {

--- a/test/unit/psql.test.js
+++ b/test/unit/psql.test.js
@@ -54,7 +54,7 @@ describe('psql', function() {
 	opt2.host = '127.0.0.1';
 	var pg2 = new PSQL(opt2);
 
-        assert.ok(pg1.dbkey() !== pg2.dbkey(),
+        assert.notStrictEqual(pg1.dbkey(), pg2.dbkey(), 'both PSQL objects using same dbkey ' + pg1.dbkey());
                   'both PSQL objects using same dbkey ' + pg1.dbkey());
     });
 

--- a/test/unit/psql.test.js
+++ b/test/unit/psql.test.js
@@ -45,6 +45,19 @@ describe('psql', function() {
         assert.ok(_.isString(pg1.dbkey()), "pg1 dbkey is " + pg1.dbkey());
     });
 
+    it('dbkey depends on the dbhost', function () {
+	var opt1 = _.clone(dbopts_anon);
+	opt1.host = '192.0.0.8';
+	var pg1 = new PSQL(opt1);
+
+	var opt2 = _.clone(dbopts_anon);
+	opt2.host = '127.0.0.1';
+	var pg2 = new PSQL(opt2);
+
+        assert.ok(pg1.dbkey() !== pg2.dbkey(),
+                  'both PSQL objects using same dbkey ' + pg1.dbkey());
+    });
+
 });
 
 

--- a/test/unit/psql.test.js
+++ b/test/unit/psql.test.js
@@ -55,7 +55,6 @@ describe('psql', function() {
 	var pg2 = new PSQL(opt2);
 
         assert.notStrictEqual(pg1.dbkey(), pg2.dbkey(), 'both PSQL objects using same dbkey ' + pg1.dbkey());
-                  'both PSQL objects using same dbkey ' + pg1.dbkey());
     });
 
 });


### PR DESCRIPTION
Include the host and port in the DB key, so that if it changes its IP (due to a migration), then the in-memory types cache queries again for the new key (possibly changing its oid values).

This fixes #38 