### PR TITLE
Add optional timeout parameter to query

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,14 +13,14 @@
     "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
     "immed"         : true,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
 //    "indent"        : 4,        // {int} Number of spaces to use for indentation
-//    "latedef"       : true,    // true: Require variables/functions to be defined before being used
+//    "latedef"       : false,    // true: Require variables/functions to be defined before being used
     "newcap"        : true,    // true: Require capitalization of all constructor functions e.g. `new F()`
     "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
-    "noempty"       : true,     // true: Prohibit use of empty blocks
+//    "noempty"       : true,     // true: Prohibit use of empty blocks
     "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
     "nonew"         : true,    // true: Prohibit use of constructors for side-effects (without assignment)
 //    "plusplus"      : false,    // true: Prohibit use of `++` & `--`
-//    "quotmark"      : true,    // Quotation mark consistency:
+//    "quotmark"      : false,    // Quotation mark consistency:
 //    //   false    : do nothing (default)
 //    //   true     : ensure whatever is used is consistent
 //    //   "single" : require single quotes
@@ -28,7 +28,7 @@
     "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
     "unused"        : true,     // true: Require all defined variables be used
     "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
-    "maxparams"     : 4,    // {int} Max number of formal params allowed per function
+//    "maxparams"     : false,    // {int} Max number of formal params allowed per function
 //    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
 //    "maxstatements" : false,    // {int} Max number statements per function
 //    "maxcomplexity" : 6,    // {int} Max cyclomatic complexity per function
@@ -40,7 +40,7 @@
     "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
 //    "eqnull"        : false,     // true: Tolerate use of `== null`
 //    "es5"           : false,     // true: Allow ES5 syntax (ex: getters and setters)
-//    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+   "esnext"        : true,     // true: Allow ES.next (ES6) syntax (ex: `const`)
 //    "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
 //    // (ex: `for each`, multiple try/catch, function expression…)
 //    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
@@ -84,10 +84,15 @@
 
     // Custom Globals
     "globals"       : { // additional predefined global variables
-        "describe": true,
-        "it": true,
-        "before": true,
+        "suite": true,
+        "suiteSetup": true,
+        "test": true,
+        "suiteTeardown": true,
         "beforeEach": true,
-        "after": true
+        "afterEach": true,
+        "before": true,
+        "after": true,
+        "describe": true,
+        "it": true
     }
 }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
-## Version 0.13.2 (yyyy-mm-dd)
-
+## Version 0.13.2 (2019-09-10)
+ - Add optional timeout parameter to `PGSQL.query`. 
 
 ## Version 0.13.1 (2018-12-10)
  - Include host and port in the dbkey, so that type cache is

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ CartoDB's [Windshaft](https://github.com/CartoDB/Windshaft) and [CartoDB-SQL-API
 projects.
 
 # Requirements
- * node >= 4
- * npm / yarn
+ * node >= 10
+ * npm
  * postgres
 
 # Install dependencies

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -311,7 +311,7 @@ var PSQL = function(connectionParams, poolParams, options) {
      * Returns error if any query fails
      * Returns the result of the last query (if successful)
      */
-    function query_array(client, sql, params, callback) {
+    function queryArray(client, sql, params, callback) {
         client.query(sql[0], params, (err, result) => {
             sql.shift();
             if (err) {
@@ -321,7 +321,7 @@ var PSQL = function(connectionParams, poolParams, options) {
                 return callback(err, result);
             }
 
-            return query_array(client, sql, params, callback);
+            return queryArray(client, sql, params, callback);
         });
     }
 
@@ -354,7 +354,7 @@ var PSQL = function(connectionParams, poolParams, options) {
                 sql_array.unshift(`SET statement_timeout=${timeout};`);
             }
 
-            query_array(client, sql_array, params, (err, result) => {
+            queryArray(client, sql_array, params, (err, result) => {
                 done(err);
                 return callback(err, result);
             });

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -305,8 +305,37 @@ var PSQL = function(connectionParams, poolParams, options) {
         return pg.Client.prototype.escapeLiteral(str);
     };
 
-    me.query = function(sql, params, callback, readonly) {
+
+    /**
+     * Executes an array of queries.
+     * Returns error if any query fails
+     * Returns the result of the last query (if successful)
+     */
+    function query_array(client, sql, params, callback) {
+        client.query(sql[0], params, (err, result) => {
+            sql.shift();
+            if (err) {
+                return callback(err);
+            }
+            if (sql.length === 0) {
+                return callback(err, result);
+            }
+
+            return query_array(client, sql, params, callback);
+        });
+    }
+
+    /**
+     *
+     * @param {String} sql - Query
+     * @param {Object} params - Query parameters
+     * @param {Function} callback - (error, result)
+     * @param {Boolean} readonly - If set, the query will be READ ONLY
+     * @param {Integer} timeout - Milliseconds to timeout the query
+     */
+    me.query = function(sql, params, callback, readonly, timeout) {
         if (typeof params === 'function') {
+          timeout = readonly;
           readonly = callback;
           callback = params;
           params = [];
@@ -317,10 +346,15 @@ var PSQL = function(connectionParams, poolParams, options) {
                 return callback(err);
             }
             if (!!readonly) {
-                sql = 'SET TRANSACTION READ ONLY; ' + sql;
+                sql = `SET TRANSACTION READ ONLY; ${sql}`;
             }
-            client.query(sql, params, function(err, result) {
-                // Release client to the pool.
+
+            let sql_array = [ sql ];
+            if (timeout !== undefined) {
+                sql_array.unshift(`SET statement_timeout=${timeout};`);
+            }
+
+            query_array(client, sql_array, params, (err, result) => {
                 done(err);
                 return callback(err, result);
             });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "docker-test": "./docker-test.sh"
     },
     "engines": {
-        "node": ">= 4.5.0"
+        "node": "^10.15.1",
+        "npm": "^6.4.1"
     }
 }

--- a/test/integration/psql.test.js
+++ b/test/integration/psql.test.js
@@ -173,6 +173,33 @@ describe('psql config-object:' + useConfigObject, function() {
         });
     });
 
+    describe('timeout', function() {
+        it('should fail when the query times out', function(done){
+            var psql = new PSQL(dbopts_auth);
+            psql.query('select pg_sleep(0.2)', function(err) {
+                assert.ok(err);
+                assert.ok(err.message.match(/canceling statement due to statement timeout/));
+                done();
+            }, false, 100);
+        });
+
+        it('should work again without timeout being passed', function(done){
+            var psql = new PSQL(dbopts_auth);
+            psql.query('select pg_sleep(0.2)', function(err) {
+                assert.ok(!err);
+                done();
+            }, false);
+        });
+
+        it('should work when timeout is bigger than the query time', function(done){
+            var psql = new PSQL(dbopts_auth);
+            psql.query('select pg_sleep(0.2)', function(err) {
+                assert.ok(!err);
+                done();
+            }, false, 500);
+        });
+    });
+
     it('should parse float4', function(done) {
         var psql = new PSQL(dbopts_auth);
         psql.query('select ARRAY[1.0::float4,null]::float4[] as f', function(err, result) {


### PR DESCRIPTION
Adds an extra optional parameter to .query() to set the timeout of the client. This way you can ensure that the timeout option is set exactly to the client where the query is going to be executed (instead of relying on it being reused).