### PR TITLE
[sc189175] Bump `node-postgres` from 6 to 8 and implement a Cursor mode

### DIFF
--- a/lib/psql.js
+++ b/lib/psql.js
@@ -241,7 +241,7 @@ var PSQL = function(connectionParams, poolParams, options) {
         });
     };
 
-    me.eventedQuery = function(sql, params, callback){
+    me.eventedQuery = function(sql, useCursor, params, callback){
         var that = this;
         if (typeof params === 'function') {
           callback = params;
@@ -254,20 +254,20 @@ var PSQL = function(connectionParams, poolParams, options) {
                 return callback(err);
             }
 
-            var cursor = client.query(new Cursor(sql, params));
+            var handler = useCursor ? client.query(new Cursor(sql, params)) : client.query(sql, params);
 
             function maxRowSizeListener(message) {
-                cursor.emit('error', new Error('Row too large, was ' + message.length + ' bytes'));
+                handler.emit('error', new Error('Row too large, was ' + message.length + ' bytes'));
             }
 
             // forward notices to query
             var noticeListener = function() {
-                cursor.emit('notice', arguments);
+                handler.emit('notice', arguments);
             };
             client.on('notice', noticeListener);
 
             var gotError = false;
-            cursor.on('error', function(err) {
+            handler.on('error', function(err) {
                 client.removeListener('maxRowSize', maxRowSizeListener);
                 client.removeListener('notice', noticeListener);
                 gotError = true;
@@ -279,7 +279,7 @@ var PSQL = function(connectionParams, poolParams, options) {
             // NOTE: for some obscure reason passing "done" directly
             //       as the listener works but can be slower
             //      (by x2 factor!)
-            cursor.on('end', function() {
+            handler.on('end', function() {
                 client.removeListener('maxRowSize', maxRowSizeListener);
                 client.removeListener('notice', noticeListener);
                 if (!gotError) {
@@ -288,10 +288,10 @@ var PSQL = function(connectionParams, poolParams, options) {
             });
 
             var queryCanceller = function() {
-                cursor.close();
+                useCursor ? handler.close() : pool.end();
             };
 
-            return callback(null, cursor, queryCanceller);
+            return callback(null, handler, queryCanceller);
         });
     };
 

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -254,7 +254,7 @@ var PSQL = function(connectionParams, poolParams, options) {
                 return callback(err);
             }
 
-            var handler = useCursor ? client.query(new Cursor(sql, params)) : client.query(sql, params);
+            var handler = useCursor ? client.query(new Cursor(sql, params)) : client.query(new pg.Query(sql, params));
 
             function maxRowSizeListener(message) {
                 handler.emit('error', new Error('Row too large, was ' + message.length + ' bytes'));

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -257,6 +257,7 @@ var PSQL = function(connectionParams, poolParams, options) {
             var handler = useCursor ? client.query(new Cursor(sql, params)) : client.query(new pg.Query(sql, params));
 
             function maxRowSizeListener(message) {
+                if (!useCursor) client.end();
                 handler.emit('error', new Error('Row too large, was ' + message.length + ' bytes'));
             }
 
@@ -288,7 +289,7 @@ var PSQL = function(connectionParams, poolParams, options) {
             });
 
             var queryCanceller = function() {
-                useCursor ? handler.close() : pool.end();
+                useCursor ? handler.close() : client.end();
             };
 
             return callback(null, handler, queryCanceller);

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -4,15 +4,11 @@ var _ = require('underscore');
 var debug = require('debug')('cartodb-psql');
 var QueryWrapper = require('./query_wrapper');
 var pg = require('pg');//.native; // disabled for now due to: https://github.com/brianc/node-postgres/issues/48
+var Cursor = require('pg-cursor')
 
 var stdTypeName = require('./oid-to-name');
 // Holds a typeId->typeName mapping for each database ever connected to
 var extTypeName = {};
-
-pg.on('error', function () {
-    // All errors will be handled synchronously or at client level
-    // this avoid uncaughtException
-});
 
 // Workaround for https://github.com/Vizzuality/CartoDB-SQL-API/issues/100
 var types = pg.types;
@@ -73,16 +69,6 @@ var PSQL = function(connectionParams, poolParams, options) {
     // pool params will have precedence over global or default settings
     poolParams = poolParams || {};
     _poolParams = _.extend(_poolParams, poolParams);
-
-    // Max database connections in the pool
-    // Subsequent connections will block waiting for a free slot
-    pg.defaults.poolSize = _poolParams.size;
-
-    // Milliseconds of idle time before removing connection from pool
-    pg.defaults.poolIdleTimeout = _poolParams.idleTimeout;
-
-    // Frequency to check for idle clients within the pool, ms
-    pg.defaults.reapIntervalMillis = _poolParams.reapInterval;
 
     // Max row size returned by PG stream
     pg.defaults.maxRowSize = options.maxRowSize || globalSettings.db_max_row_size;
@@ -149,7 +135,12 @@ var PSQL = function(connectionParams, poolParams, options) {
         user: me.username(),
         password: me.password(),
         keepAlive: keepAliveConfig,
-        ssl: false
+        ssl: false,
+        // Max database connections in the pool
+        // Subsequent connections will block waiting for a free slot
+        max: _poolParams.size,
+        // Milliseconds of idle time before removing connection from pool
+        idleTimeoutMillis: _poolParams.idleTimeout
     };
 
     me.getConnectionConfig = function () {
@@ -158,6 +149,13 @@ var PSQL = function(connectionParams, poolParams, options) {
         }
         return me.conString;
     };
+
+    var pool = new pg.Pool(me.getConnectionConfig());
+
+    pool.on('error', function () {
+        // All errors will be handled synchronously or at client level
+        // this avoid uncaughtException
+    });
 
     me.dbkey = function(){
         return this.database() + ":" + this.dbhost() + ":" + me.dbport();
@@ -168,7 +166,7 @@ var PSQL = function(connectionParams, poolParams, options) {
         if (extTypeName[db]) {
             return cb();
         }
-        this.dbConnect(this.getConnectionConfig(), function(err, client, done) {
+        this.dbConnect(function(err, client, done) {
             if (err) {
                 return cb(err);
             }
@@ -220,10 +218,11 @@ var PSQL = function(connectionParams, poolParams, options) {
         return { srid: srid, ndims: ndims, wkbtype: wkbtype };
     };
 
-    me.dbConnect = function(conConfig, cb) {
-        pg.connect(conConfig, function(err, client, done) {
+    me.dbConnect = function(cb) {
+        var that = this;
+        pool.connect(function(err, client, done) {
             if ( err ) {
-                debug("PostgreSQL connection error: %s - connection config: %s", err, conConfig);
+                debug("PostgreSQL connection error: %s - connection config: %s", err, that.getConnectionConfig());
                 err = new Error("cannot connect to the database");
                 err.http_status = 500; // connection errors are internal
             }
@@ -238,7 +237,7 @@ var PSQL = function(connectionParams, poolParams, options) {
                 return cb(err);
             }
 
-            that.dbConnect(that.getConnectionConfig(), cb);
+            that.dbConnect(cb);
         });
     };
 
@@ -255,21 +254,20 @@ var PSQL = function(connectionParams, poolParams, options) {
                 return callback(err);
             }
 
-            var query = client.query(sql, params);
+            var cursor = client.query(new Cursor(sql, params));
 
             function maxRowSizeListener(message) {
-                pg.cancel(that.getConnectionConfig(), client, query);
-                query.emit('error', new Error('Row too large, was ' + message.length + ' bytes'));
+                cursor.emit('error', new Error('Row too large, was ' + message.length + ' bytes'));
             }
 
             // forward notices to query
             var noticeListener = function() {
-                query.emit('notice', arguments);
+                cursor.emit('notice', arguments);
             };
             client.on('notice', noticeListener);
 
             var gotError = false;
-            query.on('error', function(err) {
+            cursor.on('error', function(err) {
                 client.removeListener('maxRowSize', maxRowSizeListener);
                 client.removeListener('notice', noticeListener);
                 gotError = true;
@@ -281,7 +279,7 @@ var PSQL = function(connectionParams, poolParams, options) {
             // NOTE: for some obscure reason passing "done" directly
             //       as the listener works but can be slower
             //      (by x2 factor!)
-            query.on('end', function() {
+            cursor.on('end', function() {
                 client.removeListener('maxRowSize', maxRowSizeListener);
                 client.removeListener('notice', noticeListener);
                 if (!gotError) {
@@ -290,10 +288,10 @@ var PSQL = function(connectionParams, poolParams, options) {
             });
 
             var queryCanceller = function() {
-                pg.cancel(undefined, client, query);
+                cursor.close();
             };
 
-            return callback(null, query, queryCanceller);
+            return callback(null, cursor, queryCanceller);
         });
     };
 
@@ -311,8 +309,8 @@ var PSQL = function(connectionParams, poolParams, options) {
      * Returns error if any query fails
      * Returns the result of the last query (if successful)
      */
-    function queryArray(client, sql, params, callback) {
-        client.query(sql[0], params, (err, result) => {
+    function queryArray(client, sql, _params, callback) {
+        client.query(sql[0], (err, result) => {
             sql.shift();
             if (err) {
                 return callback(err);
@@ -321,7 +319,7 @@ var PSQL = function(connectionParams, poolParams, options) {
                 return callback(err, result);
             }
 
-            return queryArray(client, sql, params, callback);
+            return queryArray(client, sql, _params, callback);
         });
     }
 
@@ -366,12 +364,12 @@ var PSQL = function(connectionParams, poolParams, options) {
 
         var count = Object.keys(pg._pools).length;
 
-        pg.once('end', function () {
+        pool.once('end', function () {
             debug(count + ' pools were shutting down successfully');
             callback();
         });
 
-        pg.end();
+        pool.end();
     };
 
     return me;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cartodb-psql",
-    "version": "0.13.1",
+    "version": "0.14.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -15,6 +15,7 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
@@ -65,9 +66,9 @@
             "dev": true
         },
         "buffer-writer": {
-            "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
-            "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+            "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
         },
         "camelcase": {
             "version": "1.2.1",
@@ -307,11 +308,6 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
-        "generic-pool": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
-            "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8="
-        },
         "glob": {
             "version": "5.0.15",
             "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -392,14 +388,14 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "is-buffer": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
             "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "isarray": {
             "version": "0.0.1",
@@ -434,11 +430,6 @@
                 "which": "^1.1.1",
                 "wordwrap": "^1.0.0"
             }
-        },
-        "js-string-escape": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-            "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
         },
         "js-yaml": {
             "version": "3.9.0",
@@ -485,6 +476,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-buffer": "^1.1.5"
             }
@@ -584,7 +576,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
             "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -678,9 +671,9 @@
             }
         },
         "ms": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "nopt": {
             "version": "3.0.6",
@@ -690,11 +683,6 @@
             "requires": {
                 "abbrev": "1"
             }
-        },
-        "object-assign": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-            "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
         },
         "once": {
             "version": "1.4.0",
@@ -738,9 +726,9 @@
             }
         },
         "packet-reader": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
-            "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+            "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -749,23 +737,26 @@
             "dev": true
         },
         "pg": {
-            "version": "github:cartodb/node-postgres#5417d7b29b7272ca2e71bb396899ab3f177a9ae6",
-            "from": "github:cartodb/node-postgres#6.4.2-cdb2",
+            "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg?cdb-8.7.1-development",
+            "integrity": "sha512-UBFtk4WlwNq4E6O8UnmHSp/4/szQIAWfCrruOdohkX0OGPSMUYzC9HEN6MLu/5AuN4rjwSdKZa9jafaBxO/ldA==",
             "requires": {
-                "buffer-writer": "1.0.1",
-                "js-string-escape": "1.0.1",
-                "packet-reader": "0.3.1",
-                "pg-connection-string": "0.1.3",
-                "pg-pool": "1.*",
-                "pg-types": "1.*",
-                "pgpass": "1.*",
-                "semver": "4.3.2"
+                "buffer-writer": "2.0.0",
+                "packet-reader": "1.0.0",
+                "pg-connection-string": "^2.5.0",
+                "pg-pool": "^3.4.1",
+                "pg-protocol": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-protocol?cdb-8.7.1-development",
+                "pg-types": "^2.1.0",
+                "pgpass": "1.x"
             }
         },
         "pg-connection-string": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-            "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+            "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+        },
+        "pg-cursor": {
+            "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-cursor?cdb-8.7.1-development",
+            "integrity": "sha512-5w5vuqEfk+baVKE36D/Yc3nPj5NhJ75tl9ypHILs3yLhClIwKxZxBUKWezgkphAr9v9N0YfGnfV0NicwHrnToA=="
         },
         "pg-int8": {
             "version": "1.0.1",
@@ -773,38 +764,38 @@
             "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
         },
         "pg-pool": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
-            "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
-            "requires": {
-                "generic-pool": "2.4.3",
-                "object-assign": "4.1.0"
-            }
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.4.1.tgz",
+            "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ=="
+        },
+        "pg-protocol": {
+            "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-protocol?cdb-8.7.1-development",
+            "integrity": "sha512-b4Qp9Nf1DWEpJ7PcUuv9ZkHruRYm3PfKPNLRdx2SC9W2xLb4mP2MHDcA6x7SIQFwffLjJ5NW2ESNipGEYyxaaQ=="
         },
         "pg-types": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
-            "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
             "requires": {
                 "pg-int8": "1.0.1",
-                "postgres-array": "~1.0.0",
+                "postgres-array": "~2.0.0",
                 "postgres-bytea": "~1.0.0",
-                "postgres-date": "~1.0.0",
+                "postgres-date": "~1.0.4",
                 "postgres-interval": "^1.1.0"
             }
         },
         "pgpass": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
-            "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+            "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
             "requires": {
-                "split": "^1.0.0"
+                "split2": "^3.1.1"
             }
         },
         "postgres-array": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
-            "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
         },
         "postgres-bytea": {
             "version": "1.0.0",
@@ -812,14 +803,14 @@
             "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
         },
         "postgres-date": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
-            "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
         },
         "postgres-interval": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
-            "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
             "requires": {
                 "xtend": "^4.0.0"
             }
@@ -846,7 +837,8 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "resolve": {
             "version": "1.1.7",
@@ -864,11 +856,6 @@
                 "align-text": "^0.1.1"
             }
         },
-        "semver": {
-            "version": "4.3.2",
-            "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-            "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
-        },
         "shelljs": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
@@ -885,12 +872,37 @@
                 "amdefine": ">=0.0.4"
             }
         },
-        "split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+        "split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
             "requires": {
-                "through": "2"
+                "readable-stream": "^3.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
             }
         },
         "sprintf-js": {
@@ -919,11 +931,6 @@
             "requires": {
                 "has-flag": "^1.0.0"
             }
-        },
-        "through": {
-            "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "type-check": {
             "version": "0.3.2",
@@ -967,10 +974,15 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
             "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
         },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
         "which": {
-            "version": "1.2.14",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-            "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
@@ -996,9 +1008,9 @@
             "dev": true
         },
         "xtend": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "yargs": {
             "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "debug": "^3.1.0",
-        "pg": "github:cartodb/node-postgres#6.4.2-cdb2",
+        "pg": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg?cdb-8.7.1-development",
+        "pg-cursor": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-cursor?cdb-8.7.1-development",
         "underscore": "~1.6.0"
     },
     "devDependencies": {


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/189175/sql-api-oom-errors-when-exporting-data#activity-194230)

### Changes

- Bump `node-postgres` from 6 to 8 and apply required changes (based on [upgrading guide](https://node-postgres.com/guides/upgrading))
- Add a new option to send a query to the database using a `Cursor` instead of a `Query` (legacy mode).